### PR TITLE
Add doc for associating AD app with PC account

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ Please refer to the setup scripts for your operating system for easy installatio
 - [macOS](setup/macos.sh) - installs and uses [Homebrew](https://brew.sh/) to install tools.
 - [Windows](setup/windows.ps1) - installs and uses [Chocolatey](https://chocolatey.org/) (default) to install tools. To install without Chocolatey, run `./windows.ps1 -useChocolatey $false`.
 
-### Step 3: Modify Offer Template Files
+### Step 3: Associate an Azure AD application with your Partner Center account
+
+The scripts in this repository use the Partner Center API to create and manage offers. To use the scripts, you must first associate an Azure AD application with your Partner Center account. Follow the instructions in the Commercial Marketplace [documentation](https://learn.microsoft.com/en-us/azure/marketplace/submission-api-onboard) to create an Azure AD application and associate it with your Partner Center account.
+
+### Step 4: Modify Offer Template Files
 
 Use the following offer templates to build your own Commercial Marketplace offerings. Each offer template includes a README file that contains instructions on how to build the offer and modify it for your use case.
 
@@ -42,7 +46,7 @@ This offer template demonstrates how to build a solution template Azure Applicat
 
 This offer template demonstrates how to create a Windows Server 2019 virtual machine image with Chocolatey and Microsoft Edge installed. The image can then be used to create an Azure Virtual Machine offer.
 
-### Step 4: Create GitHub Workflows
+### Step 5: Create GitHub Workflows
 
 GitHub [actions](.github/actions/) and [starter workflows](workflow-templates/) are provided to automate the build, test and publish process for Commercial Marketplace offers. To use an action, refer to it as follows in your workflow:
 ```

--- a/README.md
+++ b/README.md
@@ -48,7 +48,22 @@ This offer template demonstrates how to create a Windows Server 2019 virtual mac
 
 ### Step 5: Create GitHub Workflows
 
-GitHub [actions](.github/actions/) and [starter workflows](workflow-templates/) are provided to automate the build, test and publish process for Commercial Marketplace offers. To use an action, refer to it as follows in your workflow:
+GitHub [actions](.github/actions/) and [starter workflows](workflow-templates/) are provided to automate the build, test and publish process for Commercial Marketplace offers.
+
+Before using a workflow or action, create a new **actions** repository secret (AZURE_CREDENTIALS) with the following:
+```
+{
+  "clientId": "<Azure AD application client ID>",
+  "clientSecret": "<Azure AD application client secret>",
+  "subscriptionId": "<Azure subscription ID>",
+  "tenantId": "<Azure AD application tenant ID>",
+  "resourceManagerEndpointUrl": "https://management.azure.com/"
+}
+```
+
+For more information on creating a GitHub actions repository secret, see [Creating encrypted secrets for a repository](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
+
+To use an action, refer to it as follows in your workflow:
 ```
 microsoft/commercial-marketplace-offer-solution/.github/actions/[ACTION DIRECTORY]
 ```

--- a/marketplace/virtual-machine/basic-windows-vm/README.md
+++ b/marketplace/virtual-machine/basic-windows-vm/README.md
@@ -17,7 +17,14 @@ az group create --name MyResourceGroup --location westus
 az storage account create -n mystorageacct -g MyResourceGroup -l westus --sku Standard_LRS
 ```
 
-## Step 3: Modify the template for your use case
+## Step 3: Add config.yml file
+
+To run the Azure Portal CLI commands for virtual machine offers, you will need to create a `config.yml` in the `scripts` directory. You can create a copy from the [config.yml.tmpl](../../../scripts/config.yml.tmpl) template file and fill in the following values:
+- aad_id: the client ID of the Azure AD application associated with your Partner Center account
+- aad_secret: the client secret of the Azure AD application associated with your Partner Center account
+- tenant_id: the tenant ID of the Azure AD application associated with your Partner Center account
+
+## Step 4: Modify the template for your use case
 You can use this offer template as a base for your own VM offer. Modify the noted files below to suit your needs.
 
 ### Customize the Packer templates
@@ -44,7 +51,7 @@ If changes are made to the build Packer template (`build.BasicWindowsVMImage.pkr
 
 Please refer to the [Pester documentation](https://pester.dev/docs/quick-start) for more information on how to write Pester tests.
 
-## Step 4: Create the virtual machine image
+## Step 5: Create the virtual machine image
 Update the [variables.pkr.json](variables.pkr.json) to match your newly created storage account and resource group. You can also modify any of the other variables in the file to fit your need.
 
 Build the image and get the VHD URI by running the following command:
@@ -54,9 +61,10 @@ Build the image and get the VHD URI by running the following command:
 
 Once the script has completed successfully, it will output the SAS URI of the VHD created in the storage account. Take a copy of the URI for the next step.
 
-## Step 5: Validate the virtual machine image
+## Step 6: Validate the virtual machine image
 Before creating a virtual machine offer using the image created in the step above, we need to run it through a validation process to ensure that the image meets all of the Azure Marketplace publishing requirements. The VHD URI returned in the previous step will be required.
 
+In the `scripts` directory, run:
 ```
 ./validate_virtualMachineImage.ps1 -vhdUri "<VHD URI>" -location westus
 ```
@@ -79,9 +87,10 @@ Clean up the resources by deleting the VM resource group:
 az group delete -n MyVmResourceGroup
 ```
 
-## Step 6: Create the virtual machine offer
+## Step 7: Create the virtual machine offer
 Before we create the virtual machine offer, we need to update the `publisherId` in the [offer listing config](listing_config.json). Once updated, we can create the virtual machine offer, using the VHD URI returned from the **Create the virtual machine image** step.
 
+In the `scripts` directory, run:
 ```
 ./add_virtualMachineOffer.ps1 -vhdUri "<VHD URI>" -vmOfferConfigFile ../marketplace/virtual-machine/basic-windows-vm/listing_config.json -logosPath ../marketplace/virtual-machine/basic-windows-vm/logos -storageAccountName mystorageacct
 ```
@@ -90,7 +99,7 @@ During the execution of this script, dynamic variables will be parsed into the `
 
 Once the script has completed successfully, a draft virtual machine offer will have been created in [Microsoft Partner Center](https://partner.microsoft.com/en-us/dashboard/marketplace-offers/overview).
 
-## Step 7: Publishing a Virtual Machine Offer
+## Step 8: Publishing a Virtual Machine Offer
 Once the draft offer created in the above step has been reviewed and confirmed, the offer can be submitted for publishing.
 
 To start the publishing process:

--- a/scripts/config.yml.tmpl
+++ b/scripts/config.yml.tmpl
@@ -1,0 +1,3 @@
+aad_id:
+aad_secret:
+tenant_id:


### PR DESCRIPTION
Add documentation for associated an Azure AD application with user's Partner Center account. This will give users permissions to use the Partner Center APIs.