### PR TITLE
Fix package.ps1 script

### DIFF
--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -37,13 +37,10 @@ if ("" -ne $offerId)
   ((Get-Content $mainTemplateFile) -Replace 'pid-[A-z0-9]{8}-[A-z0-9]{4}-[A-z0-9]{4}-[A-z0-9]{4}-[A-z0-9]{12}-partnercenter', $partnerCenterId) | Out-File -Force $mainTemplateFile
 }
 
-Copy-Item "$assetsFolderPath\createUiDefinition.json"
-Copy-Item "$assetsFolderPath\*.ps1"
+Copy-Item "$assetsFolderPath\*" -Recurse -Exclude "parameters.json*","*.bicep"
 
 Set-Location "..\"
-Compress-Archive -Update -Path "assets\createUiDefinition.json" -DestinationPath "marketplacePackage.zip"
-Compress-Archive -Update -Path "assets\mainTemplate.json" -DestinationPath "marketplacePackage.zip"
-Compress-Archive -Update -Path "assets\*.ps1" -DestinationPath "marketplacePackage.zip"
+Compress-Archive -Path "assets\*" -DestinationPath "marketplacePackage.zip" -Force
 
 Set-Location $scriptFolder
 


### PR DESCRIPTION
The package.ps1 script wasn't creating the zip file when .ps1 files weren't present. This fix should zip up everything in the app contents folder of the offer except the Bicep files and parameters files.