### PR TITLE
On PR Publish to Marketplace in parallel to ARMTTK

### DIFF
--- a/workflow-templates/solutiontemplate.pr.yml
+++ b/workflow-templates/solutiontemplate.pr.yml
@@ -48,7 +48,6 @@ jobs:
         shell: pwsh
   VerifyOfferCreation:
     runs-on: ubuntu-latest
-    needs: ValidateARMTemplates
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
I have found that I needed to test out publishing to the marketplace to ensure the solution is working before I am ready to take on the ARM-TTK issues that were also popping. 

While the certification phase would fail with ARM-TTK issues, users could still create at least Previews